### PR TITLE
Added an option to manually control tank threat colors.

### DIFF
--- a/temp_cata/gui.lua
+++ b/temp_cata/gui.lua
@@ -7476,6 +7476,33 @@ local function guiPositionAndScale()
     anchorThreatColor.enemyColorThreatHideSolo:SetPoint("TOPLEFT", anchorThreatColor.enemyColorThreatCombatOnlyPlayer, "BOTTOMLEFT", 0, pixelsBetweenBoxes)
     CreateTooltipTwo(anchorThreatColor.enemyColorThreatHideSolo, "Turn off while Solo", "Don't show threat colors when I am not in a group.")
 
+    anchorThreatColor.disableAutoTankDetection = CreateCheckbox("disableAutoTankDetection", "Don't use automatic Tank detection", contentFrame)
+    anchorThreatColor.disableAutoTankDetection:SetPoint("TOPLEFT", anchorThreatColor.enemyColorThreatHideSolo, "BOTTOMLEFT", 0, pixelsBetweenBoxes)
+    CreateTooltipTwo(anchorThreatColor.disableAutoTankDetection, "Disable Auto Tank Detection", "Manual control over whether you are considered a tank or not.")
+
+    anchorThreatColor.useTankColors = CreateCheckbox("useTankColors", "Use Tank Colors", contentFrame)
+    anchorThreatColor.useTankColors:SetPoint("TOPLEFT", anchorThreatColor.disableAutoTankDetection, "BOTTOMLEFT", 15, pixelsBetweenBoxes)
+    CreateTooltipTwo(anchorThreatColor.useTankColors, "Use Tank Colors", "Force the use of Tank colors.\n\nIf unchecked, DPS/Heal colors will be used.")
+
+    local function UpdateTankColorCheckboxState()
+        if anchorThreatColor.disableAutoTankDetection:GetChecked() then
+            anchorThreatColor.useTankColors:Enable()
+        else
+            anchorThreatColor.useTankColors:Disable()
+        end
+    end
+
+    anchorThreatColor.disableAutoTankDetection:HookScript("OnClick", function()
+        StaticPopup_Show("BBP_CONFIRM_RELOAD")
+        UpdateTankColorCheckboxState()
+    end)
+
+    anchorThreatColor.useTankColors:HookScript("OnClick", function()
+        StaticPopup_Show("BBP_CONFIRM_RELOAD")
+    end)
+
+    UpdateTankColorCheckboxState()
+
 
     ----
 

--- a/temp_tbc/BetterBlizzPlates.lua
+++ b/temp_tbc/BetterBlizzPlates.lua
@@ -3234,7 +3234,7 @@ function BBP.ColorThreat(frame)
     local config = frame.BetterBlizzPlates and frame.BetterBlizzPlates.config or InitializeNameplateSettings(frame)
     local r, g, b
 
-    if BBP.isRoleTank then
+    if BetterBlizzPlatesDB.useTankColors or (BBP.isRoleTank and not BetterBlizzPlatesDB.disableAutoTankDetection) then
         -- Default color: no aggro
         r, g, b = unpack(BetterBlizzPlatesDB.tankNoAggroColorRGB)
 


### PR DESCRIPTION
i'm playing cat druid on tbc and i always get the tank colors
because the check is just for the talent points so i added an option to deactivate the automatic tank detection

(i don't know if cata and tbc shares a gui - maybe it has to be changed in the cata/BetterBlizzPlates.lua 🤷 )