### PR TITLE
Add user-managed profiles with per-character assignment

### DIFF
--- a/BetterBlizzPlates.toc
+++ b/BetterBlizzPlates.toc
@@ -11,6 +11,7 @@
 embeds.xml
 
 init.lua
+temp_shared\Profiles.lua
 retail\temp_tww.lua
 temp_shared\ImportExport.lua
 

--- a/BetterBlizzPlates_Cata.toc
+++ b/BetterBlizzPlates_Cata.toc
@@ -11,6 +11,7 @@
 embeds.xml
 
 init.lua
+temp_shared\Profiles.lua
 temp_shared\ImportExport.lua
 
 temp_cata\modules\combat.lua

--- a/BetterBlizzPlates_Mists.toc
+++ b/BetterBlizzPlates_Mists.toc
@@ -11,6 +11,7 @@
 embeds.xml
 
 init.lua
+temp_shared\Profiles.lua
 temp_shared\ImportExport.lua
 
 temp_cata\modules\combat.lua

--- a/BetterBlizzPlates_TBC.toc
+++ b/BetterBlizzPlates_TBC.toc
@@ -11,6 +11,7 @@
 embeds.xml
 
 init.lua
+temp_shared\Profiles.lua
 temp_shared\ImportExport.lua
 
 temp_cata\modules\combat.lua

--- a/BetterBlizzPlates_Vanilla.toc
+++ b/BetterBlizzPlates_Vanilla.toc
@@ -11,6 +11,7 @@
 embeds.xml
 
 init.lua
+temp_shared\Profiles.lua
 temp_shared\ImportExport.lua
 
 temp_era\modules\combat.lua

--- a/BetterBlizzPlates_Wrath.toc
+++ b/BetterBlizzPlates_Wrath.toc
@@ -11,6 +11,7 @@
 embeds.xml
 
 init.lua
+temp_shared\Profiles.lua
 temp_shared\ImportExport.lua
 
 temp_cata\modules\combat.lua

--- a/midnight/BetterBlizzPlates.lua
+++ b/midnight/BetterBlizzPlates.lua
@@ -994,6 +994,55 @@ local function InitializeSavedVariables()
     end
 end
 
+-- Profiles engine hooks (see temp_shared/Profiles.lua).
+-- Expose this flavor's defaults + additive merge so the engine can deep-copy a
+-- pristine profile and re-run the merge on the correct profile at PLAYER_LOGIN.
+BBP.defaultSettings = defaultSettings
+BBP.InitializeSavedVariables = InitializeSavedVariables
+
+-- Finalize a freshly created/reset profile (already a deep copy of defaults):
+-- pre-mark every one-shot bootstrap/migration flag in this flavor's
+-- ADDON_LOADED handler as "done" so the post-switch reload does NOT snapshot
+-- CVars, capture client fonts, run destructive DB cleans, or replay onboarding
+-- popups; then carry client-descriptive captures (Blizzard font defaults,
+-- nameplateStyle) from the source profile. These describe the client install,
+-- not user settings.
+function BBP.FinalizeNewProfile(profile, source)
+    source = source or {}
+    -- One-shot guard flags (setting them "done" => skip on next load).
+    profile.firstSaveComplete = true
+    profile.hasSaved = true
+    profile.dbCleanMidnight = true
+    profile.cleanedScaleScale = true
+    profile.clickAreaMidnightFix = true
+    profile.fixedNameplateStyle = true
+    profile.totemIndicatorUpdatedForMidnight = true
+    profile.classIndicatorUpdated2 = true
+    profile.partyPointerUpdated2 = true
+    profile.nameplateResourceScaleUpdated = true
+    profile.fixedFriendlyHealthbarHide = true
+    profile.castBarIconPosReset = true
+    profile.nameplateResourcePositionFix = true
+    profile.friendlyNameplateTogglesUpdated = true
+    -- prdLegacyLook is not in defaultSettings; a nil value triggers a one-time
+    -- onboarding print + mutation on load. A fresh profile is never "legacy".
+    profile.prdLegacyLook = false
+    profile.prdSplitLines = true
+    -- Client-descriptive captures carried from the source profile.
+    for _, k in ipairs({
+        "defaultLargeNamePlateFont", "defaultLargeFontSize", "defaultLargeNamePlateFontFlags",
+        "defaultNamePlateFont", "defaultFontSize", "defaultNamePlateFontFlags",
+        "defaultNamePlateOutlinedFont", "defaultOutlinedFontSize", "defaultNamePlateOutlinedFontFlags",
+        "old_defaultLargeNamePlateFont", "old_defaultLargeFontSize", "old_defaultLargeNamePlateFontFlags",
+        "old_defaultNamePlateFont", "old_defaultFontSize", "old_defaultNamePlateFontFlags",
+        "nameplateStyle",
+    }) do
+        if source[k] ~= nil then
+            profile[k] = source[k]
+        end
+    end
+end
+
 function BBP.ResetTotemList()
     BetterBlizzPlatesDB.totemIndicatorNpcList = {}
     BetterBlizzPlatesDB.totemIndicatorNpcList = defaultSettings.totemIndicatorNpcList
@@ -1444,7 +1493,9 @@ local function ResetNameplates()
 end
 
 local function ResetBBP()
-    BetterBlizzPlatesDB = {}
+    -- Wipe the active profile in place (do NOT rebind the global: the logout
+    -- swap would discard a new table and the reset would silently no-op).
+    for k in pairs(BetterBlizzPlatesDB) do BetterBlizzPlatesDB[k] = nil end
 
     ResetNameplates()
 

--- a/midnight/gui.lua
+++ b/midnight/gui.lua
@@ -1909,7 +1909,7 @@ local function ShowProfileConfirmation(profileName, class, profileFunction, addi
     local color = CLASS_COLORS[class] or "|cffffffff"
     local icon = CLASS_ICONS[class] or "groupfinder-icon-role-leader"
     local profileText = string.format("|A:%s:16:16|a %s%s|r", icon, color, profileName.." Profile")
-    local confirmationText = titleText .. "This action will delete all settings and apply\nthe " .. profileText .. " and reload the UI.\n\n" .. noteText .. "Are you sure you want to continue?"
+    local confirmationText = titleText .. "This action will overwrite your current profile\n(|cffffd700" .. BBP.GetCurrentProfileName() .. "|r) and apply\nthe " .. profileText .. " and reload the UI.\n\n" .. noteText .. "Are you sure you want to continue?"
 
     StaticPopupDialogs["BBP_CONFIRM_PROFILE"].text = confirmationText
     StaticPopup_Show("BBP_CONFIRM_PROFILE", nil, nil, { func = profileFunction })
@@ -2057,7 +2057,7 @@ local function CreateImportExportUI(parent, title, dataTable, posX, posY, tableN
     wipeButton:SetScript("OnMouseDown", function(self, button)
         if button == "RightButton" and IsShiftKeyDown() and IsAltKeyDown() then
             if title == "Full Profile" then
-                BetterBlizzPlatesDB = nil
+                for k in pairs(BetterBlizzPlatesDB) do BetterBlizzPlatesDB[k] = nil end
             else
                 BetterBlizzPlatesDB[tableName] = nil
             end
@@ -12666,6 +12666,193 @@ local function guiMisc()
     -- end)
 end
 
+--#########################################
+-- Profiles subpanel (user-managed database profiles; engine in temp_shared/Profiles.lua)
+local function guiProfilesPanel()
+    local guiProfiles = CreateFrame("Frame")
+    guiProfiles.name = "Profiles"
+    guiProfiles.parent = BetterBlizzPlates.name
+    local guiProfilesCategory = Settings.RegisterCanvasLayoutSubcategory(BBP.category, guiProfiles, guiProfiles.name, guiProfiles.name)
+    CreateTitle(guiProfiles)
+
+    local bgImg = guiProfiles:CreateTexture(nil, "BACKGROUND")
+    bgImg:SetAtlas("professions-recipe-background")
+    bgImg:SetPoint("CENTER", guiProfiles, "CENTER", -8, 4)
+    bgImg:SetSize(680, 610)
+    bgImg:SetAlpha(0.4)
+    bgImg:SetVertexColor(0, 0, 0)
+
+    -- Intro / reset explanation
+    local introText = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    introText:SetPoint("TOPLEFT", guiProfiles, "TOPLEFT", 30, -80)
+    introText:SetJustifyH("LEFT")
+    introText:SetText("You can change the active database profile, so you can have\ndifferent settings for every character.")
+
+    local resetText = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    resetText:SetPoint("TOPLEFT", introText, "BOTTOMLEFT", 0, -12)
+    resetText:SetJustifyH("LEFT")
+    resetText:SetText("Reset the current profile back to its default values, in case\nyour configuration is broken, or you simply want to start over.")
+
+    -- Reset Profile button + Current Profile label
+    local resetButton = CreateFrame("Button", nil, guiProfiles, "UIPanelButtonTemplate")
+    resetButton:SetSize(120, 24)
+    resetButton:SetText("Reset Profile")
+    resetButton:SetPoint("TOPLEFT", resetText, "BOTTOMLEFT", 0, -16)
+    -- Deliberately "dangerous" look (bright red + outline) instead of the dim red
+    -- that read as a disabled/greyed button. The OUTLINE matches the intro window's
+    -- "Exit, No Profile" idiom for making button text pop; hover/pushed states are
+    -- texture-based on UIPanelButtonTemplate and stay normal.
+    resetButton:GetFontString():SetTextColor(1, 0.3, 0.3)
+    local resetFont, resetSize = resetButton:GetFontString():GetFont()
+    resetButton:GetFontString():SetFont(resetFont, resetSize, "OUTLINE")
+    resetButton:SetScript("OnClick", function()
+        BBP.ResetProfile()
+    end)
+
+    local currentProfileLabel = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    currentProfileLabel:SetPoint("LEFT", resetButton, "RIGHT", 16, 0)
+    currentProfileLabel:SetJustifyH("LEFT")
+
+    -- Create / choose explanation
+    local createText = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    createText:SetPoint("TOPLEFT", resetButton, "BOTTOMLEFT", 0, -24)
+    createText:SetJustifyH("LEFT")
+    createText:SetText("You can either create a new profile by entering a name in the\neditbox, or choose one of the already existing profiles.")
+
+    -- New profile editbox
+    local newLabel = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    newLabel:SetPoint("TOPLEFT", createText, "BOTTOMLEFT", 4, -16)
+    newLabel:SetText("New")
+
+    local newEditBox = CreateFrame("EditBox", nil, guiProfiles, "InputBoxTemplate")
+    newEditBox:SetSize(150, 20)
+    newEditBox:SetPoint("TOPLEFT", newLabel, "BOTTOMLEFT", 2, -4)
+    newEditBox:SetAutoFocus(false)
+    newEditBox:SetFontObject("ChatFontNormal")
+    newEditBox:SetScript("OnEscapePressed", function(self) self:ClearFocus() end)
+    -- Shared create handler so the "Add" button and pressing Enter do the same thing.
+    local function submitNewProfile()
+        local text = newEditBox:GetText()
+        newEditBox:ClearFocus()
+        if text and text:gsub("%s", "") ~= "" then
+            newEditBox:SetText("")
+            BBP.CreateProfile(text) -- engine trims, rejects empty/duplicate, then switches (popup -> reload)
+        end
+    end
+    newEditBox:SetScript("OnEnterPressed", submitNewProfile)
+
+    -- "Add" button: same create action as Enter. Matches the list-panel editbox+button
+    -- idiom (UIPanelButtonTemplate, 60x24, "Add", anchored to the right of the editbox).
+    local newAddButton = CreateFrame("Button", nil, guiProfiles, "UIPanelButtonTemplate")
+    newAddButton:SetSize(60, 24)
+    newAddButton:SetText("Add")
+    newAddButton:SetPoint("LEFT", newEditBox, "RIGHT", 10, 0)
+    newAddButton:SetScript("OnClick", submitNewProfile)
+
+    -- Dropdown factory: menu contents rebuild live on each open via BBP.GetProfiles().
+    local function CreateProfilesDropdown(dropdownName, width, excludeCurrent, markCurrent, onSelect, excludeDefault)
+        local dropdown = LibDD:Create_UIDropDownMenu(dropdownName, guiProfiles)
+        LibDD:UIDropDownMenu_SetWidth(dropdown, width)
+        LibDD:UIDropDownMenu_Initialize(dropdown, function(self, level)
+            local info = LibDD:UIDropDownMenu_CreateInfo()
+            local current = BBP.GetCurrentProfileName()
+            for _, pname in ipairs(BBP.GetProfiles()) do
+                if not (excludeCurrent and pname == current) and not (excludeDefault and pname == "Default") then
+                    info.text = pname
+                    info.arg1 = pname
+                    info.checked = (markCurrent and pname == current)
+                    info.colorCode = "|cFFFFFF00"
+                    info.func = function(_, arg1)
+                        onSelect(arg1)
+                    end
+                    LibDD:UIDropDownMenu_AddButton(info)
+                end
+            end
+        end)
+        return dropdown
+    end
+
+    -- Existing Profiles dropdown (switch active profile)
+    local existingLabel = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    -- Shifted right by the "Add" button width + gap so it stays above the dropdown.
+    existingLabel:SetPoint("BOTTOMLEFT", newEditBox, "TOPLEFT", 260, 18)
+    existingLabel:SetText("Existing Profiles")
+
+    local existingDropdown = CreateProfilesDropdown("BBPExistingProfilesDropdown", 160, false, true, function(name)
+        BBP.SetProfile(name) -- confirm popup -> reload (engine no-ops if already active)
+    end)
+    -- Anchored to the "Add" button (not the editbox) so it clears the new button.
+    existingDropdown:SetPoint("LEFT", newAddButton, "RIGHT", 14, -2)
+
+    -- Copy From dropdown (copies into the active profile)
+    local copyText = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    copyText:SetPoint("TOPLEFT", newEditBox, "BOTTOMLEFT", -2, -42)
+    copyText:SetJustifyH("LEFT")
+    copyText:SetText("Copy the settings from one existing profile into the currently\nactive profile.")
+
+    local copyLabel = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    copyLabel:SetPoint("TOPLEFT", copyText, "BOTTOMLEFT", 4, -16)
+    copyLabel:SetText("Copy From")
+
+    local copyDropdown = CreateProfilesDropdown("BBPCopyProfileDropdown", 160, true, false, function(name)
+        BBP.CopyProfile(name) -- confirm popup -> reload
+    end)
+    copyDropdown:SetPoint("TOPLEFT", copyLabel, "BOTTOMLEFT", -16, -4)
+
+    -- Delete a Profile dropdown
+    local deleteText = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    deleteText:SetPoint("TOPLEFT", copyDropdown, "BOTTOMLEFT", 16, -20)
+    deleteText:SetJustifyH("LEFT")
+    deleteText:SetText("Delete existing and unused profiles from the database to save\nspace, and cleanup the SavedVariables file.")
+
+    local deleteLabel = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    deleteLabel:SetPoint("TOPLEFT", deleteText, "BOTTOMLEFT", 4, -16)
+    deleteLabel:SetText("Delete a Profile")
+
+    local refreshProfilesUI
+
+    -- excludeDefault (last arg) keeps "Default" out of the delete list: the engine
+    -- hard-blocks deleting Default, and it must never be offered in the UI.
+    local deleteDropdown = CreateProfilesDropdown("BBPDeleteProfileDropdown", 160, true, false, function(name)
+        BBP.pendingProfileDelete = name
+        StaticPopup_Show("BBP_CONFIRM_PROFILE_DELETE", name)
+    end, true)
+    deleteDropdown:SetPoint("TOPLEFT", deleteLabel, "BOTTOMLEFT", -16, -4)
+
+    -- Delete confirmation. The engine's BBP.DeleteProfile deletes immediately (no
+    -- popup and no reload), so the GUI owns the confirm + refresh here.
+    StaticPopupDialogs["BBP_CONFIRM_PROFILE_DELETE"] = {
+        text = "Delete the BetterBlizzPlates profile \"%s\"?\n\nThis cannot be undone.",
+        button1 = "Delete",
+        button2 = "Cancel",
+        OnAccept = function()
+            local name = BBP.pendingProfileDelete
+            BBP.pendingProfileDelete = nil
+            if name then
+                BBP.DeleteProfile(name)
+                if refreshProfilesUI then refreshProfilesUI() end
+            end
+        end,
+        timeout = 0,
+        whileDead = true,
+        hideOnEscape = true,
+        preferredIndex = 3,
+    }
+
+    -- Refresh the labels/selected-text that don't auto-update (dropdown menu
+    -- contents themselves rebuild on open). Runs on build, on panel show, and
+    -- after a delete (switch/copy/reset reload the UI, so they don't need it).
+    refreshProfilesUI = function()
+        currentProfileLabel:SetText("Current Profile: |cffffd700" .. BBP.GetCurrentProfileName() .. "|r")
+        LibDD:UIDropDownMenu_SetText(existingDropdown, BBP.GetCurrentProfileName())
+        LibDD:UIDropDownMenu_SetText(copyDropdown, "Copy From...")
+        LibDD:UIDropDownMenu_SetText(deleteDropdown, "Delete a Profile...")
+    end
+
+    refreshProfilesUI()
+    guiProfiles:HookScript("OnShow", refreshProfilesUI)
+end
+
 local function guiImportAndExport()
     local guiImportAndExport = CreateFrame("Frame")
     guiImportAndExport.name = "Import & Export"--"|A:GarrMission_CurrencyIcon-Material:19:19|a Misc"
@@ -13109,6 +13296,7 @@ function BBP.LoadGUI()
     guiCVarControl()
     guiMisc()
     guiImportAndExport()
+    guiProfilesPanel()
     --guiTotemList()
     guiSupport()
     BetterBlizzPlates.guiLoaded = true

--- a/temp_cata/BetterBlizzPlates.lua
+++ b/temp_cata/BetterBlizzPlates.lua
@@ -1103,6 +1103,45 @@ local function InitializeSavedVariables()
     end
 end
 
+-- Profiles engine hooks (see temp_shared/Profiles.lua).
+BBP.defaultSettings = defaultSettings
+BBP.InitializeSavedVariables = InitializeSavedVariables
+
+-- Pre-mark this flavor's one-shot bootstrap/migration flags "done" on a freshly
+-- created/reset profile so the post-switch reload does NOT snapshot CVars,
+-- capture client fonts, run destructive DB cleans, or replay onboarding popups
+-- (the MoP/Cata update popup, totem-list updates); then carry client-descriptive
+-- font captures from the source profile.
+function BBP.FinalizeNewProfile(profile, source)
+    source = source or {}
+    profile.firstSaveComplete = true
+    profile.hasSaved = true
+    profile.mopUpdated = true
+    profile.mopBetaUpdated2 = true
+    profile.mopBetaUpdated3 = true
+    profile.totemListUpdateMop1 = true
+    profile.totemListUpdateMop2 = true
+    profile.totemListUpdateMop3 = true
+    profile.friendlyNameplateTogglesUpdated = true
+    profile.auraWhitelistColorsUpdated = true
+    profile.auraWhitelistAlphaUpdated = true
+    profile.castBarIconPosReset = true
+    profile.cleanedScaleScale = true
+    profile.nameplateResourcePositionFix = true
+    for _, k in ipairs({
+        "defaultLargeNamePlateFont", "defaultLargeFontSize", "defaultLargeNamePlateFontFlags",
+        "defaultNamePlateFont", "defaultFontSize", "defaultNamePlateFontFlags",
+        "defaultNamePlateOutlinedFont", "defaultOutlinedFontSize", "defaultNamePlateOutlinedFontFlags",
+        "old_defaultLargeNamePlateFont", "old_defaultLargeFontSize", "old_defaultLargeNamePlateFontFlags",
+        "old_defaultNamePlateFont", "old_defaultFontSize", "old_defaultNamePlateFontFlags",
+        "nameplateStyle",
+    }) do
+        if source[k] ~= nil then
+            profile[k] = source[k]
+        end
+    end
+end
+
 function BBP.ResetTotemList()
     BetterBlizzPlatesDB.totemIndicatorNpcList = {}
     BetterBlizzPlatesDB.totemIndicatorNpcList = defaultSettings.totemIndicatorNpcList
@@ -1381,7 +1420,9 @@ local function ResetNameplates()
 end
 
 local function ResetBBP()
-    BetterBlizzPlatesDB = {}
+    -- Wipe the active profile in place (do NOT rebind the global: the logout
+    -- swap would discard a new table and the reset would silently no-op).
+    for k in pairs(BetterBlizzPlatesDB) do BetterBlizzPlatesDB[k] = nil end
 
     ResetNameplates()
 

--- a/temp_cata/gui.lua
+++ b/temp_cata/gui.lua
@@ -1726,7 +1726,7 @@ local function ShowProfileConfirmation(profileName, class, profileFunction, addi
     local color = CLASS_COLORS[class] or "|cffffffff"
     local icon = CLASS_ICONS[class] or "groupfinder-icon-role-leader"
     local profileText = string.format("|A:%s:16:16|a %s%s|r", icon, color, profileName.." Profile")
-    local confirmationText = titleText .. "This action will delete all settings and apply\nthe " .. profileText .. " and reload the UI.\n\n" .. noteText .. "Are you sure you want to continue?"
+    local confirmationText = titleText .. "This action will overwrite your current profile\n(|cffffd700" .. BBP.GetCurrentProfileName() .. "|r) and apply\nthe " .. profileText .. " and reload the UI.\n\n" .. noteText .. "Are you sure you want to continue?"
 
     StaticPopupDialogs["BBP_CONFIRM_PROFILE"].text = confirmationText
     StaticPopup_Show("BBP_CONFIRM_PROFILE", nil, nil, { func = profileFunction })
@@ -1852,7 +1852,7 @@ local function CreateImportExportUI(parent, title, dataTable, posX, posY, tableN
     wipeButton:SetScript("OnMouseDown", function(self, button)
         if button == "RightButton" and IsShiftKeyDown() and IsAltKeyDown() then
             if title == "Full Profile" then
-                BetterBlizzPlatesDB = nil
+                for k in pairs(BetterBlizzPlatesDB) do BetterBlizzPlatesDB[k] = nil end
             else
                 BetterBlizzPlatesDB[tableName] = nil
             end
@@ -11213,6 +11213,193 @@ local function guiSupport()
     boxTwoTex:SetPoint("BOTTOM", boxTwo, "TOP", 0, 1)
 end
 
+--#########################################
+-- Profiles subpanel (user-managed database profiles; engine in temp_shared/Profiles.lua)
+local function guiProfilesPanel()
+    local guiProfiles = CreateFrame("Frame")
+    guiProfiles.name = "Profiles"
+    guiProfiles.parent = BetterBlizzPlates.name
+    local guiProfilesCategory = Settings.RegisterCanvasLayoutSubcategory(BBP.category, guiProfiles, guiProfiles.name, guiProfiles.name)
+    CreateTitle(guiProfiles)
+
+    local bgImg = guiProfiles:CreateTexture(nil, "BACKGROUND")
+    bgImg:SetAtlas("professions-recipe-background")
+    bgImg:SetPoint("CENTER", guiProfiles, "CENTER", -8, 4)
+    bgImg:SetSize(680, 610)
+    bgImg:SetAlpha(0.4)
+    bgImg:SetVertexColor(0, 0, 0)
+
+    -- Intro / reset explanation
+    local introText = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    introText:SetPoint("TOPLEFT", guiProfiles, "TOPLEFT", 30, -80)
+    introText:SetJustifyH("LEFT")
+    introText:SetText("You can change the active database profile, so you can have\ndifferent settings for every character.")
+
+    local resetText = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    resetText:SetPoint("TOPLEFT", introText, "BOTTOMLEFT", 0, -12)
+    resetText:SetJustifyH("LEFT")
+    resetText:SetText("Reset the current profile back to its default values, in case\nyour configuration is broken, or you simply want to start over.")
+
+    -- Reset Profile button + Current Profile label
+    local resetButton = CreateFrame("Button", nil, guiProfiles, "UIPanelButtonTemplate")
+    resetButton:SetSize(120, 24)
+    resetButton:SetText("Reset Profile")
+    resetButton:SetPoint("TOPLEFT", resetText, "BOTTOMLEFT", 0, -16)
+    -- Deliberately "dangerous" look (bright red + outline) instead of the dim red
+    -- that read as a disabled/greyed button. The OUTLINE matches the intro window's
+    -- "Exit, No Profile" idiom for making button text pop; hover/pushed states are
+    -- texture-based on UIPanelButtonTemplate and stay normal.
+    resetButton:GetFontString():SetTextColor(1, 0.3, 0.3)
+    local resetFont, resetSize = resetButton:GetFontString():GetFont()
+    resetButton:GetFontString():SetFont(resetFont, resetSize, "OUTLINE")
+    resetButton:SetScript("OnClick", function()
+        BBP.ResetProfile()
+    end)
+
+    local currentProfileLabel = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    currentProfileLabel:SetPoint("LEFT", resetButton, "RIGHT", 16, 0)
+    currentProfileLabel:SetJustifyH("LEFT")
+
+    -- Create / choose explanation
+    local createText = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    createText:SetPoint("TOPLEFT", resetButton, "BOTTOMLEFT", 0, -24)
+    createText:SetJustifyH("LEFT")
+    createText:SetText("You can either create a new profile by entering a name in the\neditbox, or choose one of the already existing profiles.")
+
+    -- New profile editbox
+    local newLabel = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    newLabel:SetPoint("TOPLEFT", createText, "BOTTOMLEFT", 4, -16)
+    newLabel:SetText("New")
+
+    local newEditBox = CreateFrame("EditBox", nil, guiProfiles, "InputBoxTemplate")
+    newEditBox:SetSize(150, 20)
+    newEditBox:SetPoint("TOPLEFT", newLabel, "BOTTOMLEFT", 2, -4)
+    newEditBox:SetAutoFocus(false)
+    newEditBox:SetFontObject("ChatFontNormal")
+    newEditBox:SetScript("OnEscapePressed", function(self) self:ClearFocus() end)
+    -- Shared create handler so the "Add" button and pressing Enter do the same thing.
+    local function submitNewProfile()
+        local text = newEditBox:GetText()
+        newEditBox:ClearFocus()
+        if text and text:gsub("%s", "") ~= "" then
+            newEditBox:SetText("")
+            BBP.CreateProfile(text) -- engine trims, rejects empty/duplicate, then switches (popup -> reload)
+        end
+    end
+    newEditBox:SetScript("OnEnterPressed", submitNewProfile)
+
+    -- "Add" button: same create action as Enter. Matches the list-panel editbox+button
+    -- idiom (UIPanelButtonTemplate, 60x24, "Add", anchored to the right of the editbox).
+    local newAddButton = CreateFrame("Button", nil, guiProfiles, "UIPanelButtonTemplate")
+    newAddButton:SetSize(60, 24)
+    newAddButton:SetText("Add")
+    newAddButton:SetPoint("LEFT", newEditBox, "RIGHT", 10, 0)
+    newAddButton:SetScript("OnClick", submitNewProfile)
+
+    -- Dropdown factory: menu contents rebuild live on each open via BBP.GetProfiles().
+    local function CreateProfilesDropdown(dropdownName, width, excludeCurrent, markCurrent, onSelect, excludeDefault)
+        local dropdown = LibDD:Create_UIDropDownMenu(dropdownName, guiProfiles)
+        LibDD:UIDropDownMenu_SetWidth(dropdown, width)
+        LibDD:UIDropDownMenu_Initialize(dropdown, function(self, level)
+            local info = LibDD:UIDropDownMenu_CreateInfo()
+            local current = BBP.GetCurrentProfileName()
+            for _, pname in ipairs(BBP.GetProfiles()) do
+                if not (excludeCurrent and pname == current) and not (excludeDefault and pname == "Default") then
+                    info.text = pname
+                    info.arg1 = pname
+                    info.checked = (markCurrent and pname == current)
+                    info.colorCode = "|cFFFFFF00"
+                    info.func = function(_, arg1)
+                        onSelect(arg1)
+                    end
+                    LibDD:UIDropDownMenu_AddButton(info)
+                end
+            end
+        end)
+        return dropdown
+    end
+
+    -- Existing Profiles dropdown (switch active profile)
+    local existingLabel = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    -- Shifted right by the "Add" button width + gap so it stays above the dropdown.
+    existingLabel:SetPoint("BOTTOMLEFT", newEditBox, "TOPLEFT", 260, 18)
+    existingLabel:SetText("Existing Profiles")
+
+    local existingDropdown = CreateProfilesDropdown("BBPExistingProfilesDropdown", 160, false, true, function(name)
+        BBP.SetProfile(name) -- confirm popup -> reload (engine no-ops if already active)
+    end)
+    -- Anchored to the "Add" button (not the editbox) so it clears the new button.
+    existingDropdown:SetPoint("LEFT", newAddButton, "RIGHT", 14, -2)
+
+    -- Copy From dropdown (copies into the active profile)
+    local copyText = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    copyText:SetPoint("TOPLEFT", newEditBox, "BOTTOMLEFT", -2, -42)
+    copyText:SetJustifyH("LEFT")
+    copyText:SetText("Copy the settings from one existing profile into the currently\nactive profile.")
+
+    local copyLabel = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    copyLabel:SetPoint("TOPLEFT", copyText, "BOTTOMLEFT", 4, -16)
+    copyLabel:SetText("Copy From")
+
+    local copyDropdown = CreateProfilesDropdown("BBPCopyProfileDropdown", 160, true, false, function(name)
+        BBP.CopyProfile(name) -- confirm popup -> reload
+    end)
+    copyDropdown:SetPoint("TOPLEFT", copyLabel, "BOTTOMLEFT", -16, -4)
+
+    -- Delete a Profile dropdown
+    local deleteText = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    deleteText:SetPoint("TOPLEFT", copyDropdown, "BOTTOMLEFT", 16, -20)
+    deleteText:SetJustifyH("LEFT")
+    deleteText:SetText("Delete existing and unused profiles from the database to save\nspace, and cleanup the SavedVariables file.")
+
+    local deleteLabel = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    deleteLabel:SetPoint("TOPLEFT", deleteText, "BOTTOMLEFT", 4, -16)
+    deleteLabel:SetText("Delete a Profile")
+
+    local refreshProfilesUI
+
+    -- excludeDefault (last arg) keeps "Default" out of the delete list: the engine
+    -- hard-blocks deleting Default, and it must never be offered in the UI.
+    local deleteDropdown = CreateProfilesDropdown("BBPDeleteProfileDropdown", 160, true, false, function(name)
+        BBP.pendingProfileDelete = name
+        StaticPopup_Show("BBP_CONFIRM_PROFILE_DELETE", name)
+    end, true)
+    deleteDropdown:SetPoint("TOPLEFT", deleteLabel, "BOTTOMLEFT", -16, -4)
+
+    -- Delete confirmation. The engine's BBP.DeleteProfile deletes immediately (no
+    -- popup and no reload), so the GUI owns the confirm + refresh here.
+    StaticPopupDialogs["BBP_CONFIRM_PROFILE_DELETE"] = {
+        text = "Delete the BetterBlizzPlates profile \"%s\"?\n\nThis cannot be undone.",
+        button1 = "Delete",
+        button2 = "Cancel",
+        OnAccept = function()
+            local name = BBP.pendingProfileDelete
+            BBP.pendingProfileDelete = nil
+            if name then
+                BBP.DeleteProfile(name)
+                if refreshProfilesUI then refreshProfilesUI() end
+            end
+        end,
+        timeout = 0,
+        whileDead = true,
+        hideOnEscape = true,
+        preferredIndex = 3,
+    }
+
+    -- Refresh the labels/selected-text that don't auto-update (dropdown menu
+    -- contents themselves rebuild on open). Runs on build, on panel show, and
+    -- after a delete (switch/copy/reset reload the UI, so they don't need it).
+    refreshProfilesUI = function()
+        currentProfileLabel:SetText("Current Profile: |cffffd700" .. BBP.GetCurrentProfileName() .. "|r")
+        LibDD:UIDropDownMenu_SetText(existingDropdown, BBP.GetCurrentProfileName())
+        LibDD:UIDropDownMenu_SetText(copyDropdown, "Copy From...")
+        LibDD:UIDropDownMenu_SetText(deleteDropdown, "Delete a Profile...")
+    end
+
+    refreshProfilesUI()
+    guiProfiles:HookScript("OnShow", refreshProfilesUI)
+end
+
 local function guiImportAndExport()
     local guiImportAndExport = CreateFrame("Frame")
     guiImportAndExport.name = "Import & Export"--"|A:GarrMission_CurrencyIcon-Material:19:19|a Misc"
@@ -11339,6 +11526,7 @@ function BBP.LoadGUI()
     guiCVarControl()
     guiMisc()
     guiImportAndExport()
+    guiProfilesPanel()
     guiTotemList()
     guiSupport()
     BetterBlizzPlates.guiLoaded = true

--- a/temp_era/BetterBlizzPlates.lua
+++ b/temp_era/BetterBlizzPlates.lua
@@ -831,6 +831,40 @@ local function InitializeSavedVariables()
     end
 end
 
+-- Profiles engine hooks (see temp_shared/Profiles.lua).
+BBP.defaultSettings = defaultSettings
+BBP.InitializeSavedVariables = InitializeSavedVariables
+
+-- Pre-mark this flavor's one-shot bootstrap/migration flags "done" on a freshly
+-- created/reset profile so the post-switch reload does NOT snapshot CVars (incl.
+-- the eraCvarOopsie refetch), capture client fonts, run destructive DB cleans,
+-- or replay onboarding; then carry client-descriptive font captures from the
+-- source profile.
+function BBP.FinalizeNewProfile(profile, source)
+    source = source or {}
+    profile.firstSaveComplete = true
+    profile.hasSaved = true
+    profile.eraCvarOopsieFixed = true
+    profile.friendlyNameplateTogglesUpdated = true
+    profile.auraWhitelistColorsUpdated = true
+    profile.auraWhitelistAlphaUpdated = true
+    profile.castBarIconPosReset = true
+    profile.cleanedScaleScale = true
+    profile.nameplateResourcePositionFix = true
+    for _, k in ipairs({
+        "defaultLargeNamePlateFont", "defaultLargeFontSize", "defaultLargeNamePlateFontFlags",
+        "defaultNamePlateFont", "defaultFontSize", "defaultNamePlateFontFlags",
+        "defaultNamePlateOutlinedFont", "defaultOutlinedFontSize", "defaultNamePlateOutlinedFontFlags",
+        "old_defaultLargeNamePlateFont", "old_defaultLargeFontSize", "old_defaultLargeNamePlateFontFlags",
+        "old_defaultNamePlateFont", "old_defaultFontSize", "old_defaultNamePlateFontFlags",
+        "nameplateStyle",
+    }) do
+        if source[k] ~= nil then
+            profile[k] = source[k]
+        end
+    end
+end
+
 function BBP.ResetTotemList()
     BetterBlizzPlatesDB.totemIndicatorNpcList = {}
     BetterBlizzPlatesDB.totemIndicatorNpcList = defaultSettings.totemIndicatorNpcList
@@ -1110,7 +1144,9 @@ local function ResetNameplates()
 end
 
 local function ResetBBP()
-    BetterBlizzPlatesDB = {}
+    -- Wipe the active profile in place (do NOT rebind the global: the logout
+    -- swap would discard a new table and the reset would silently no-op).
+    for k in pairs(BetterBlizzPlatesDB) do BetterBlizzPlatesDB[k] = nil end
 
     ResetNameplates()
 

--- a/temp_era/gui.lua
+++ b/temp_era/gui.lua
@@ -1694,7 +1694,7 @@ local function CreateImportExportUI(parent, title, dataTable, posX, posY, tableN
     wipeButton:SetScript("OnMouseDown", function(self, button)
         if button == "RightButton" and IsShiftKeyDown() and IsAltKeyDown() then
             if title == "Full Profile" then
-                BetterBlizzPlatesDB = nil
+                for k in pairs(BetterBlizzPlatesDB) do BetterBlizzPlatesDB[k] = nil end
             else
                 BetterBlizzPlatesDB[tableName] = nil
             end
@@ -4983,7 +4983,7 @@ local function guiGeneralTab()
     -- Function to show the confirmation popup with dynamic profile information
     local function ShowProfileConfirmation(profileName, profileFunction, additionalNote)
         local noteText = additionalNote or ""
-        local confirmationText = titleText .. "This action will delete all settings and apply " .. profileName .. "'s profile and reload the UI.\n\n" .. noteText .. "Are you sure you want to continue?"
+        local confirmationText = titleText .. "This action will overwrite your current profile (|cffffd700" .. BBP.GetCurrentProfileName() .. "|r) and apply " .. profileName .. "'s profile and reload the UI.\n\n" .. noteText .. "Are you sure you want to continue?"
         StaticPopupDialogs["BBP_CONFIRM_PROFILE"].text = confirmationText
         StaticPopup_Show("BBP_CONFIRM_PROFILE", nil, nil, { func = profileFunction })
     end
@@ -9239,6 +9239,193 @@ local function guiSupport()
     boxTwoTex:SetPoint("BOTTOM", boxTwo, "TOP", 0, 1)
 end
 
+--#########################################
+-- Profiles subpanel (user-managed database profiles; engine in temp_shared/Profiles.lua)
+local function guiProfilesPanel()
+    local guiProfiles = CreateFrame("Frame")
+    guiProfiles.name = "Profiles"
+    guiProfiles.parent = BetterBlizzPlates.name
+    local guiProfilesCategory = Settings.RegisterCanvasLayoutSubcategory(BBP.category, guiProfiles, guiProfiles.name, guiProfiles.name)
+    CreateTitle(guiProfiles)
+
+    local bgImg = guiProfiles:CreateTexture(nil, "BACKGROUND")
+    bgImg:SetAtlas("professions-recipe-background")
+    bgImg:SetPoint("CENTER", guiProfiles, "CENTER", -8, 4)
+    bgImg:SetSize(680, 610)
+    bgImg:SetAlpha(0.4)
+    bgImg:SetVertexColor(0, 0, 0)
+
+    -- Intro / reset explanation
+    local introText = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    introText:SetPoint("TOPLEFT", guiProfiles, "TOPLEFT", 30, -80)
+    introText:SetJustifyH("LEFT")
+    introText:SetText("You can change the active database profile, so you can have\ndifferent settings for every character.")
+
+    local resetText = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    resetText:SetPoint("TOPLEFT", introText, "BOTTOMLEFT", 0, -12)
+    resetText:SetJustifyH("LEFT")
+    resetText:SetText("Reset the current profile back to its default values, in case\nyour configuration is broken, or you simply want to start over.")
+
+    -- Reset Profile button + Current Profile label
+    local resetButton = CreateFrame("Button", nil, guiProfiles, "UIPanelButtonTemplate")
+    resetButton:SetSize(120, 24)
+    resetButton:SetText("Reset Profile")
+    resetButton:SetPoint("TOPLEFT", resetText, "BOTTOMLEFT", 0, -16)
+    -- Deliberately "dangerous" look (bright red + outline) instead of the dim red
+    -- that read as a disabled/greyed button. The OUTLINE matches the intro window's
+    -- "Exit, No Profile" idiom for making button text pop; hover/pushed states are
+    -- texture-based on UIPanelButtonTemplate and stay normal.
+    resetButton:GetFontString():SetTextColor(1, 0.3, 0.3)
+    local resetFont, resetSize = resetButton:GetFontString():GetFont()
+    resetButton:GetFontString():SetFont(resetFont, resetSize, "OUTLINE")
+    resetButton:SetScript("OnClick", function()
+        BBP.ResetProfile()
+    end)
+
+    local currentProfileLabel = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    currentProfileLabel:SetPoint("LEFT", resetButton, "RIGHT", 16, 0)
+    currentProfileLabel:SetJustifyH("LEFT")
+
+    -- Create / choose explanation
+    local createText = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    createText:SetPoint("TOPLEFT", resetButton, "BOTTOMLEFT", 0, -24)
+    createText:SetJustifyH("LEFT")
+    createText:SetText("You can either create a new profile by entering a name in the\neditbox, or choose one of the already existing profiles.")
+
+    -- New profile editbox
+    local newLabel = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    newLabel:SetPoint("TOPLEFT", createText, "BOTTOMLEFT", 4, -16)
+    newLabel:SetText("New")
+
+    local newEditBox = CreateFrame("EditBox", nil, guiProfiles, "InputBoxTemplate")
+    newEditBox:SetSize(150, 20)
+    newEditBox:SetPoint("TOPLEFT", newLabel, "BOTTOMLEFT", 2, -4)
+    newEditBox:SetAutoFocus(false)
+    newEditBox:SetFontObject("ChatFontNormal")
+    newEditBox:SetScript("OnEscapePressed", function(self) self:ClearFocus() end)
+    -- Shared create handler so the "Add" button and pressing Enter do the same thing.
+    local function submitNewProfile()
+        local text = newEditBox:GetText()
+        newEditBox:ClearFocus()
+        if text and text:gsub("%s", "") ~= "" then
+            newEditBox:SetText("")
+            BBP.CreateProfile(text) -- engine trims, rejects empty/duplicate, then switches (popup -> reload)
+        end
+    end
+    newEditBox:SetScript("OnEnterPressed", submitNewProfile)
+
+    -- "Add" button: same create action as Enter. Matches the list-panel editbox+button
+    -- idiom (UIPanelButtonTemplate, 60x24, "Add", anchored to the right of the editbox).
+    local newAddButton = CreateFrame("Button", nil, guiProfiles, "UIPanelButtonTemplate")
+    newAddButton:SetSize(60, 24)
+    newAddButton:SetText("Add")
+    newAddButton:SetPoint("LEFT", newEditBox, "RIGHT", 10, 0)
+    newAddButton:SetScript("OnClick", submitNewProfile)
+
+    -- Dropdown factory: menu contents rebuild live on each open via BBP.GetProfiles().
+    local function CreateProfilesDropdown(dropdownName, width, excludeCurrent, markCurrent, onSelect, excludeDefault)
+        local dropdown = LibDD:Create_UIDropDownMenu(dropdownName, guiProfiles)
+        LibDD:UIDropDownMenu_SetWidth(dropdown, width)
+        LibDD:UIDropDownMenu_Initialize(dropdown, function(self, level)
+            local info = LibDD:UIDropDownMenu_CreateInfo()
+            local current = BBP.GetCurrentProfileName()
+            for _, pname in ipairs(BBP.GetProfiles()) do
+                if not (excludeCurrent and pname == current) and not (excludeDefault and pname == "Default") then
+                    info.text = pname
+                    info.arg1 = pname
+                    info.checked = (markCurrent and pname == current)
+                    info.colorCode = "|cFFFFFF00"
+                    info.func = function(_, arg1)
+                        onSelect(arg1)
+                    end
+                    LibDD:UIDropDownMenu_AddButton(info)
+                end
+            end
+        end)
+        return dropdown
+    end
+
+    -- Existing Profiles dropdown (switch active profile)
+    local existingLabel = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    -- Shifted right by the "Add" button width + gap so it stays above the dropdown.
+    existingLabel:SetPoint("BOTTOMLEFT", newEditBox, "TOPLEFT", 260, 18)
+    existingLabel:SetText("Existing Profiles")
+
+    local existingDropdown = CreateProfilesDropdown("BBPExistingProfilesDropdown", 160, false, true, function(name)
+        BBP.SetProfile(name) -- confirm popup -> reload (engine no-ops if already active)
+    end)
+    -- Anchored to the "Add" button (not the editbox) so it clears the new button.
+    existingDropdown:SetPoint("LEFT", newAddButton, "RIGHT", 14, -2)
+
+    -- Copy From dropdown (copies into the active profile)
+    local copyText = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    copyText:SetPoint("TOPLEFT", newEditBox, "BOTTOMLEFT", -2, -42)
+    copyText:SetJustifyH("LEFT")
+    copyText:SetText("Copy the settings from one existing profile into the currently\nactive profile.")
+
+    local copyLabel = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    copyLabel:SetPoint("TOPLEFT", copyText, "BOTTOMLEFT", 4, -16)
+    copyLabel:SetText("Copy From")
+
+    local copyDropdown = CreateProfilesDropdown("BBPCopyProfileDropdown", 160, true, false, function(name)
+        BBP.CopyProfile(name) -- confirm popup -> reload
+    end)
+    copyDropdown:SetPoint("TOPLEFT", copyLabel, "BOTTOMLEFT", -16, -4)
+
+    -- Delete a Profile dropdown
+    local deleteText = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    deleteText:SetPoint("TOPLEFT", copyDropdown, "BOTTOMLEFT", 16, -20)
+    deleteText:SetJustifyH("LEFT")
+    deleteText:SetText("Delete existing and unused profiles from the database to save\nspace, and cleanup the SavedVariables file.")
+
+    local deleteLabel = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    deleteLabel:SetPoint("TOPLEFT", deleteText, "BOTTOMLEFT", 4, -16)
+    deleteLabel:SetText("Delete a Profile")
+
+    local refreshProfilesUI
+
+    -- excludeDefault (last arg) keeps "Default" out of the delete list: the engine
+    -- hard-blocks deleting Default, and it must never be offered in the UI.
+    local deleteDropdown = CreateProfilesDropdown("BBPDeleteProfileDropdown", 160, true, false, function(name)
+        BBP.pendingProfileDelete = name
+        StaticPopup_Show("BBP_CONFIRM_PROFILE_DELETE", name)
+    end, true)
+    deleteDropdown:SetPoint("TOPLEFT", deleteLabel, "BOTTOMLEFT", -16, -4)
+
+    -- Delete confirmation. The engine's BBP.DeleteProfile deletes immediately (no
+    -- popup and no reload), so the GUI owns the confirm + refresh here.
+    StaticPopupDialogs["BBP_CONFIRM_PROFILE_DELETE"] = {
+        text = "Delete the BetterBlizzPlates profile \"%s\"?\n\nThis cannot be undone.",
+        button1 = "Delete",
+        button2 = "Cancel",
+        OnAccept = function()
+            local name = BBP.pendingProfileDelete
+            BBP.pendingProfileDelete = nil
+            if name then
+                BBP.DeleteProfile(name)
+                if refreshProfilesUI then refreshProfilesUI() end
+            end
+        end,
+        timeout = 0,
+        whileDead = true,
+        hideOnEscape = true,
+        preferredIndex = 3,
+    }
+
+    -- Refresh the labels/selected-text that don't auto-update (dropdown menu
+    -- contents themselves rebuild on open). Runs on build, on panel show, and
+    -- after a delete (switch/copy/reset reload the UI, so they don't need it).
+    refreshProfilesUI = function()
+        currentProfileLabel:SetText("Current Profile: |cffffd700" .. BBP.GetCurrentProfileName() .. "|r")
+        LibDD:UIDropDownMenu_SetText(existingDropdown, BBP.GetCurrentProfileName())
+        LibDD:UIDropDownMenu_SetText(copyDropdown, "Copy From...")
+        LibDD:UIDropDownMenu_SetText(deleteDropdown, "Delete a Profile...")
+    end
+
+    refreshProfilesUI()
+    guiProfiles:HookScript("OnShow", refreshProfilesUI)
+end
+
 local function guiImportAndExport()
     local guiImportAndExport = CreateFrame("Frame")
     guiImportAndExport.name = "Import & Export"--"|A:GarrMission_CurrencyIcon-Material:19:19|a Misc"
@@ -9353,6 +9540,7 @@ function BBP.LoadGUI()
     guiCVarControl()
     guiMisc()
     guiImportAndExport()
+    guiProfilesPanel()
     guiTotemList()
     guiSupport()
     BetterBlizzPlates.guiLoaded = true

--- a/temp_mop/BetterBlizzPlates.lua
+++ b/temp_mop/BetterBlizzPlates.lua
@@ -1292,6 +1292,49 @@ local function InitializeSavedVariables()
     BBP.defaultTotemIndicatorNpcList = defaultSettings.totemIndicatorNpcList
 end
 
+-- Profiles engine hooks (see temp_shared/Profiles.lua).
+BBP.defaultSettings = defaultSettings
+BBP.InitializeSavedVariables = InitializeSavedVariables
+
+-- Pre-mark this flavor's one-shot bootstrap/migration flags "done" on a freshly
+-- created/reset profile so the post-switch reload does NOT snapshot CVars,
+-- capture client fonts, force nameplate CVars, run destructive DB cleans, or
+-- replay onboarding popups (MoP update, TBC totem-list popups); then carry
+-- client-descriptive captures from the source profile.
+function BBP.FinalizeNewProfile(profile, source)
+    source = source or {}
+    profile.firstSaveComplete = true
+    profile.hasSaved = true
+    profile.mopUpdated = true
+    profile.mopBetaUpdated2 = true
+    profile.mopBetaUpdated3 = true
+    profile.totemListUpdateMop1 = true
+    profile.totemListUpdateMop2 = true
+    profile.totemListUpdateMop3 = true
+    profile.tbcTotemListUpdate1 = true
+    profile.mopUpdates = true
+    profile.disabledNewMidnightAuras = true
+    profile.fixedNameplateStyle = true
+    profile.friendlyNameplateTogglesUpdated = true
+    profile.auraWhitelistColorsUpdated = true
+    profile.auraWhitelistAlphaUpdated = true
+    profile.castBarIconPosReset = true
+    profile.cleanedScaleScale = true
+    profile.nameplateResourcePositionFix = true
+    for _, k in ipairs({
+        "defaultLargeNamePlateFont", "defaultLargeFontSize", "defaultLargeNamePlateFontFlags",
+        "defaultNamePlateFont", "defaultFontSize", "defaultNamePlateFontFlags",
+        "defaultNamePlateOutlinedFont", "defaultOutlinedFontSize", "defaultNamePlateOutlinedFontFlags",
+        "old_defaultLargeNamePlateFont", "old_defaultLargeFontSize", "old_defaultLargeNamePlateFontFlags",
+        "old_defaultNamePlateFont", "old_defaultFontSize", "old_defaultNamePlateFontFlags",
+        "nameplateStyle",
+    }) do
+        if source[k] ~= nil then
+            profile[k] = source[k]
+        end
+    end
+end
+
 function BBP.ResetTotemList()
     BetterBlizzPlatesDB.totemIndicatorNpcList = {}
     BetterBlizzPlatesDB.totemIndicatorNpcList = defaultSettings.totemIndicatorNpcList
@@ -1785,7 +1828,9 @@ local function ResetNameplates()
 end
 
 local function ResetBBP()
-    BetterBlizzPlatesDB = {}
+    -- Wipe the active profile in place (do NOT rebind the global: the logout
+    -- swap would discard a new table and the reset would silently no-op).
+    for k in pairs(BetterBlizzPlatesDB) do BetterBlizzPlatesDB[k] = nil end
 
     ResetNameplates()
 

--- a/temp_mop/gui.lua
+++ b/temp_mop/gui.lua
@@ -1716,7 +1716,7 @@ local function ShowProfileConfirmation(profileName, class, profileFunction, addi
     local color = CLASS_COLORS[class] or "|cffffffff"
     local icon = CLASS_ICONS[class] or "groupfinder-icon-role-leader"
     local profileText = string.format("|A:%s:16:16|a %s%s|r", icon, color, profileName.." Profile")
-    local confirmationText = titleText .. "This action will delete all settings and apply\nthe " .. profileText .. " and reload the UI.\n\n" .. noteText .. "Are you sure you want to continue?"
+    local confirmationText = titleText .. "This action will overwrite your current profile\n(|cffffd700" .. BBP.GetCurrentProfileName() .. "|r) and apply\nthe " .. profileText .. " and reload the UI.\n\n" .. noteText .. "Are you sure you want to continue?"
 
     StaticPopupDialogs["BBP_CONFIRM_PROFILE"].text = confirmationText
     StaticPopup_Show("BBP_CONFIRM_PROFILE", nil, nil, { func = profileFunction })
@@ -1842,7 +1842,7 @@ local function CreateImportExportUI(parent, title, dataTable, posX, posY, tableN
     wipeButton:SetScript("OnMouseDown", function(self, button)
         if button == "RightButton" and IsShiftKeyDown() and IsAltKeyDown() then
             if title == "Full Profile" then
-                BetterBlizzPlatesDB = nil
+                for k in pairs(BetterBlizzPlatesDB) do BetterBlizzPlatesDB[k] = nil end
             else
                 BetterBlizzPlatesDB[tableName] = nil
             end
@@ -11288,6 +11288,193 @@ local function guiSupport()
     boxTwoTex:SetPoint("BOTTOM", boxTwo, "TOP", 0, 1)
 end
 
+--#########################################
+-- Profiles subpanel (user-managed database profiles; engine in temp_shared/Profiles.lua)
+local function guiProfilesPanel()
+    local guiProfiles = CreateFrame("Frame")
+    guiProfiles.name = "Profiles"
+    guiProfiles.parent = BetterBlizzPlates.name
+    local guiProfilesCategory = Settings.RegisterCanvasLayoutSubcategory(BBP.category, guiProfiles, guiProfiles.name, guiProfiles.name)
+    CreateTitle(guiProfiles)
+
+    local bgImg = guiProfiles:CreateTexture(nil, "BACKGROUND")
+    bgImg:SetAtlas("professions-recipe-background")
+    bgImg:SetPoint("CENTER", guiProfiles, "CENTER", -8, 4)
+    bgImg:SetSize(680, 610)
+    bgImg:SetAlpha(0.4)
+    bgImg:SetVertexColor(0, 0, 0)
+
+    -- Intro / reset explanation
+    local introText = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    introText:SetPoint("TOPLEFT", guiProfiles, "TOPLEFT", 30, -80)
+    introText:SetJustifyH("LEFT")
+    introText:SetText("You can change the active database profile, so you can have\ndifferent settings for every character.")
+
+    local resetText = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    resetText:SetPoint("TOPLEFT", introText, "BOTTOMLEFT", 0, -12)
+    resetText:SetJustifyH("LEFT")
+    resetText:SetText("Reset the current profile back to its default values, in case\nyour configuration is broken, or you simply want to start over.")
+
+    -- Reset Profile button + Current Profile label
+    local resetButton = CreateFrame("Button", nil, guiProfiles, "UIPanelButtonTemplate")
+    resetButton:SetSize(120, 24)
+    resetButton:SetText("Reset Profile")
+    resetButton:SetPoint("TOPLEFT", resetText, "BOTTOMLEFT", 0, -16)
+    -- Deliberately "dangerous" look (bright red + outline) instead of the dim red
+    -- that read as a disabled/greyed button. The OUTLINE matches the intro window's
+    -- "Exit, No Profile" idiom for making button text pop; hover/pushed states are
+    -- texture-based on UIPanelButtonTemplate and stay normal.
+    resetButton:GetFontString():SetTextColor(1, 0.3, 0.3)
+    local resetFont, resetSize = resetButton:GetFontString():GetFont()
+    resetButton:GetFontString():SetFont(resetFont, resetSize, "OUTLINE")
+    resetButton:SetScript("OnClick", function()
+        BBP.ResetProfile()
+    end)
+
+    local currentProfileLabel = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    currentProfileLabel:SetPoint("LEFT", resetButton, "RIGHT", 16, 0)
+    currentProfileLabel:SetJustifyH("LEFT")
+
+    -- Create / choose explanation
+    local createText = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    createText:SetPoint("TOPLEFT", resetButton, "BOTTOMLEFT", 0, -24)
+    createText:SetJustifyH("LEFT")
+    createText:SetText("You can either create a new profile by entering a name in the\neditbox, or choose one of the already existing profiles.")
+
+    -- New profile editbox
+    local newLabel = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    newLabel:SetPoint("TOPLEFT", createText, "BOTTOMLEFT", 4, -16)
+    newLabel:SetText("New")
+
+    local newEditBox = CreateFrame("EditBox", nil, guiProfiles, "InputBoxTemplate")
+    newEditBox:SetSize(150, 20)
+    newEditBox:SetPoint("TOPLEFT", newLabel, "BOTTOMLEFT", 2, -4)
+    newEditBox:SetAutoFocus(false)
+    newEditBox:SetFontObject("ChatFontNormal")
+    newEditBox:SetScript("OnEscapePressed", function(self) self:ClearFocus() end)
+    -- Shared create handler so the "Add" button and pressing Enter do the same thing.
+    local function submitNewProfile()
+        local text = newEditBox:GetText()
+        newEditBox:ClearFocus()
+        if text and text:gsub("%s", "") ~= "" then
+            newEditBox:SetText("")
+            BBP.CreateProfile(text) -- engine trims, rejects empty/duplicate, then switches (popup -> reload)
+        end
+    end
+    newEditBox:SetScript("OnEnterPressed", submitNewProfile)
+
+    -- "Add" button: same create action as Enter. Matches the list-panel editbox+button
+    -- idiom (UIPanelButtonTemplate, 60x24, "Add", anchored to the right of the editbox).
+    local newAddButton = CreateFrame("Button", nil, guiProfiles, "UIPanelButtonTemplate")
+    newAddButton:SetSize(60, 24)
+    newAddButton:SetText("Add")
+    newAddButton:SetPoint("LEFT", newEditBox, "RIGHT", 10, 0)
+    newAddButton:SetScript("OnClick", submitNewProfile)
+
+    -- Dropdown factory: menu contents rebuild live on each open via BBP.GetProfiles().
+    local function CreateProfilesDropdown(dropdownName, width, excludeCurrent, markCurrent, onSelect, excludeDefault)
+        local dropdown = LibDD:Create_UIDropDownMenu(dropdownName, guiProfiles)
+        LibDD:UIDropDownMenu_SetWidth(dropdown, width)
+        LibDD:UIDropDownMenu_Initialize(dropdown, function(self, level)
+            local info = LibDD:UIDropDownMenu_CreateInfo()
+            local current = BBP.GetCurrentProfileName()
+            for _, pname in ipairs(BBP.GetProfiles()) do
+                if not (excludeCurrent and pname == current) and not (excludeDefault and pname == "Default") then
+                    info.text = pname
+                    info.arg1 = pname
+                    info.checked = (markCurrent and pname == current)
+                    info.colorCode = "|cFFFFFF00"
+                    info.func = function(_, arg1)
+                        onSelect(arg1)
+                    end
+                    LibDD:UIDropDownMenu_AddButton(info)
+                end
+            end
+        end)
+        return dropdown
+    end
+
+    -- Existing Profiles dropdown (switch active profile)
+    local existingLabel = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    -- Shifted right by the "Add" button width + gap so it stays above the dropdown.
+    existingLabel:SetPoint("BOTTOMLEFT", newEditBox, "TOPLEFT", 260, 18)
+    existingLabel:SetText("Existing Profiles")
+
+    local existingDropdown = CreateProfilesDropdown("BBPExistingProfilesDropdown", 160, false, true, function(name)
+        BBP.SetProfile(name) -- confirm popup -> reload (engine no-ops if already active)
+    end)
+    -- Anchored to the "Add" button (not the editbox) so it clears the new button.
+    existingDropdown:SetPoint("LEFT", newAddButton, "RIGHT", 14, -2)
+
+    -- Copy From dropdown (copies into the active profile)
+    local copyText = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    copyText:SetPoint("TOPLEFT", newEditBox, "BOTTOMLEFT", -2, -42)
+    copyText:SetJustifyH("LEFT")
+    copyText:SetText("Copy the settings from one existing profile into the currently\nactive profile.")
+
+    local copyLabel = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    copyLabel:SetPoint("TOPLEFT", copyText, "BOTTOMLEFT", 4, -16)
+    copyLabel:SetText("Copy From")
+
+    local copyDropdown = CreateProfilesDropdown("BBPCopyProfileDropdown", 160, true, false, function(name)
+        BBP.CopyProfile(name) -- confirm popup -> reload
+    end)
+    copyDropdown:SetPoint("TOPLEFT", copyLabel, "BOTTOMLEFT", -16, -4)
+
+    -- Delete a Profile dropdown
+    local deleteText = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontHighlight")
+    deleteText:SetPoint("TOPLEFT", copyDropdown, "BOTTOMLEFT", 16, -20)
+    deleteText:SetJustifyH("LEFT")
+    deleteText:SetText("Delete existing and unused profiles from the database to save\nspace, and cleanup the SavedVariables file.")
+
+    local deleteLabel = guiProfiles:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+    deleteLabel:SetPoint("TOPLEFT", deleteText, "BOTTOMLEFT", 4, -16)
+    deleteLabel:SetText("Delete a Profile")
+
+    local refreshProfilesUI
+
+    -- excludeDefault (last arg) keeps "Default" out of the delete list: the engine
+    -- hard-blocks deleting Default, and it must never be offered in the UI.
+    local deleteDropdown = CreateProfilesDropdown("BBPDeleteProfileDropdown", 160, true, false, function(name)
+        BBP.pendingProfileDelete = name
+        StaticPopup_Show("BBP_CONFIRM_PROFILE_DELETE", name)
+    end, true)
+    deleteDropdown:SetPoint("TOPLEFT", deleteLabel, "BOTTOMLEFT", -16, -4)
+
+    -- Delete confirmation. The engine's BBP.DeleteProfile deletes immediately (no
+    -- popup and no reload), so the GUI owns the confirm + refresh here.
+    StaticPopupDialogs["BBP_CONFIRM_PROFILE_DELETE"] = {
+        text = "Delete the BetterBlizzPlates profile \"%s\"?\n\nThis cannot be undone.",
+        button1 = "Delete",
+        button2 = "Cancel",
+        OnAccept = function()
+            local name = BBP.pendingProfileDelete
+            BBP.pendingProfileDelete = nil
+            if name then
+                BBP.DeleteProfile(name)
+                if refreshProfilesUI then refreshProfilesUI() end
+            end
+        end,
+        timeout = 0,
+        whileDead = true,
+        hideOnEscape = true,
+        preferredIndex = 3,
+    }
+
+    -- Refresh the labels/selected-text that don't auto-update (dropdown menu
+    -- contents themselves rebuild on open). Runs on build, on panel show, and
+    -- after a delete (switch/copy/reset reload the UI, so they don't need it).
+    refreshProfilesUI = function()
+        currentProfileLabel:SetText("Current Profile: |cffffd700" .. BBP.GetCurrentProfileName() .. "|r")
+        LibDD:UIDropDownMenu_SetText(existingDropdown, BBP.GetCurrentProfileName())
+        LibDD:UIDropDownMenu_SetText(copyDropdown, "Copy From...")
+        LibDD:UIDropDownMenu_SetText(deleteDropdown, "Delete a Profile...")
+    end
+
+    refreshProfilesUI()
+    guiProfiles:HookScript("OnShow", refreshProfilesUI)
+end
+
 local function guiImportAndExport()
     local guiImportAndExport = CreateFrame("Frame")
     guiImportAndExport.name = "Import & Export"--"|A:GarrMission_CurrencyIcon-Material:19:19|a Misc"
@@ -11414,6 +11601,7 @@ function BBP.LoadGUI()
     guiCVarControl()
     guiMisc()
     guiImportAndExport()
+    guiProfilesPanel()
     guiTotemList()
     guiSupport()
     BetterBlizzPlates.guiLoaded = true

--- a/temp_shared/Profiles.lua
+++ b/temp_shared/Profiles.lua
@@ -1,0 +1,584 @@
+-- Profiles.lua
+--
+-- User-managed profiles for BetterBlizzPlates (see .claude/specs/profiles.md).
+-- Loaded by every flavor TOC immediately after init.lua, so this file's
+-- ADDON_LOADED handler is registered BEFORE the main file's and therefore runs
+-- first: it migrates the saved variable to the profile structure and rebinds the
+-- global BetterBlizzPlatesDB to the active profile table before any settings are
+-- read. On PLAYER_LOGOUT the global is swapped back to the full root so WoW
+-- serializes the whole structure to disk ("logout swap").
+--
+-- Data model (root = the on-disk saved variable BetterBlizzPlatesDB):
+--   root.profiles    = { ["Default"] = { ...flat settings... }, ... }
+--   root.profileKeys = { ["Name - Realm"] = "Default", ... }
+--   root.global      = { ...account-level housekeeping (unused for now)... }
+--   root.dbVersion   = 2
+
+local ADDON = "BetterBlizzPlates"
+
+-- Root-level keys that are NOT part of a profile's flat settings.
+local RESERVED = {
+    profiles = true,
+    profileKeys = true,
+    global = true,
+    dbVersion = true,
+}
+
+--#########################################
+-- Helpers
+
+-- Deep copy that handles nested tables (aura lists, npc lists, etc.).
+local function DeepCopy(src)
+    if type(src) ~= "table" then
+        return src
+    end
+    local dst = {}
+    for k, v in pairs(src) do
+        dst[k] = DeepCopy(v)
+    end
+    return dst
+end
+BBP.DeepCopyTable = DeepCopy
+
+-- Empty a table WITHOUT changing its identity, so references held elsewhere
+-- (the rebound global, root.profiles[key]) keep pointing at the same table.
+local function WipeInPlace(t)
+    for k in pairs(t) do
+        t[k] = nil
+    end
+end
+
+local function Trim(s)
+    if type(s) ~= "string" then return "" end
+    return (s:gsub("^%s+", ""):gsub("%s+$", ""))
+end
+
+-- charKey: "Name - Realm" (AceDB-compatible). Built no earlier than our own
+-- ADDON_LOADED. Returns nil if EITHER the player name OR the realm is not yet
+-- available/known (should not happen on current clients; guarded so we never
+-- concat a nil and, critically, never persist a placeholder like "Name - Unknown"
+-- as a sticky profileKeys assignment). A nil return triggers the deferred
+-- activation path (provisional binding now, retry at PLAYER_LOGIN).
+local function BuildCharKey()
+    local name = UnitName("player")
+    if not name or name == "" or name == UNKNOWN or name == UNKNOWNOBJECT then
+        return nil
+    end
+    local realm = GetRealmName()
+    if not realm or realm == "" or realm == UNKNOWN or realm == UNKNOWNOBJECT then
+        return nil
+    end
+    return name .. " - " .. realm
+end
+
+--#########################################
+-- Migration (run once, idempotent, before anything reads settings)
+
+local function Migrate(root)
+    -- Sentinel: presence of .profiles means we already migrated.
+    if root.profiles then
+        return
+    end
+
+    local default = {}
+    local moved = {}
+    -- Copy every existing flat key into Default...
+    for k, v in pairs(root) do
+        if not RESERVED[k] then
+            default[k] = v
+            moved[#moved + 1] = k
+        end
+    end
+    -- ...then remove them from the root (move, not copy). Setting existing
+    -- fields to nil during traversal is allowed in Lua 5.1, but we collected
+    -- keys first to keep this unambiguous.
+    for _, k in ipairs(moved) do
+        root[k] = nil
+    end
+
+    root.profiles = { Default = default }
+    root.profileKeys = {}
+    root.global = {}
+    root.dbVersion = 2
+end
+
+--#########################################
+-- Activation + the rebind
+
+local function EnsureStructure(root)
+    root.profiles = root.profiles or {}
+    if not root.profiles.Default then
+        root.profiles.Default = {}
+    end
+    root.profileKeys = root.profileKeys or {}
+    root.global = root.global or {}
+end
+
+-- Resolve which profile a (possibly nil) charKey maps to. Never persists.
+local function ResolveActiveKey(root, charKey)
+    if charKey then
+        local assigned = root.profileKeys[charKey]
+        if assigned and root.profiles[assigned] then
+            return assigned
+        end
+    end
+    -- No identity, no assignment, or the assigned profile was deleted.
+    return "Default"
+end
+
+-- Second-chance activation at PLAYER_LOGIN, used ONLY when identity was not
+-- available at our ADDON_LOADED (Classic Era timing risk). At PLAYER_LOGIN
+-- UnitName("player")/GetRealmName() are guaranteed populated. Nothing between
+-- ADDON_LOADED and PLAYER_LOGIN captures the profile table long-term (every
+-- `local db = BetterBlizzPlatesDB` alias is function-local and re-read per call),
+-- so swapping the global here is seen by all subsequent reads, including the
+-- PLAYER_ENTERING_WORLD handlers (which fire AFTER PLAYER_LOGIN) that apply
+-- nameplate settings. Note: the main file's own file-scope PLAYER_LOGIN handler
+-- was registered before ours and thus runs first against the SCRATCH binding;
+-- because the equality branch below ADOPTS the scratch AS the persisted profile
+-- table (rather than copying out of it), every write made against the scratch —
+-- by that earlier handler AND by any delayed closures captured during boot — is
+-- kept, because the scratch itself is what ends up serialized. This path only
+-- triggers in the rare unresolved case.
+local function ReactivateAtLogin(root)
+    local charKey = BuildCharKey()
+    if not charKey then
+        -- Still unresolvable (defensive; should be impossible at PLAYER_LOGIN).
+        -- Stay on the SCRATCH binding for the rest of the session and persist
+        -- NOTHING: BBP.charKey remains nil so SetProfile prints a clear error, and
+        -- since the scratch is never stored in root.profiles nor serialized, the
+        -- session is effectively SANDBOXED — all changes are discarded at logout.
+        -- This matches the existing SetProfile "identity unavailable" behavior.
+        return
+    end
+
+    local activeKey = ResolveActiveKey(root, charKey)
+    BBP.charKey = charKey
+    root.profileKeys[charKey] = activeKey
+
+    -- Branch on KEYS, not table identity: the current global is the SCRATCH (a deep
+    -- copy, so it never equals a persisted profile table). hintKey is the profile
+    -- the scratch was copied FROM (recorded as BBP.activeProfileKey in Activate).
+    local hintKey = BBP.activeProfileKey
+    local scratch = BBP.profileScratch
+
+    if activeKey == hintKey then
+        -- CONVERGENT COMMON CASE: the scratch was copied from the CORRECT profile
+        -- for this character, so every write the session made to it (the additive
+        -- default-merge, one-shot migration flags, list updates, reopenOptions
+        -- clearing, font/CVar captures) is EXACTLY what a normal boot would have
+        -- written to this profile. Promote by ADOPTION: make the scratch itself the
+        -- persisted profile table (root.profiles[activeKey] = scratch) and leave the
+        -- global pointed at the scratch (Activate already bound it there). The old
+        -- persisted table for activeKey is discarded.
+        --
+        -- WHY adoption instead of the previous wipe-in-place + copy-contents-out:
+        -- the copy approach kept the persisted table's identity but orphaned the
+        -- SCRATCH object, and closures created during ADDON_LOADED (delayed popup
+        -- callbacks, retry tickers — e.g. midnight's popup handlers and era's ticker
+        -- that captured `local db = BetterBlizzPlatesDB`) still alias the scratch.
+        -- After a copy-based promotion those captured aliases point at the orphaned
+        -- scratch, so their later writes never reach the serialized profile and are
+        -- silently lost. Adoption makes the scratch the real table, so EVERY alias
+        -- captured during boot converges on the one table that is now persisted.
+        -- The discarded original is safe to drop: root.profiles was its only holder
+        -- (profileKeys/lastActiveProfile store strings), and the scratch is a deep
+        -- copy of it plus the legitimate boot writes, so no data is lost. NO reload:
+        -- the adopted profile equals the normal-boot image, nothing to re-apply.
+        if scratch then
+            root.profiles[activeKey] = scratch
+        end
+        -- Defensive re-merge against the (now adopted) persisted table. A no-op after
+        -- adoption (every default key is already present), but guarantees full
+        -- seeding even if the scratch was somehow absent (root.profiles[activeKey]
+        -- is left untouched and the global still points at it via Activate).
+        if type(BBP.InitializeSavedVariables) == "function" then
+            BBP.InitializeSavedVariables()
+        end
+        BBP.profileScratch = nil
+        root.lastActiveProfile = activeKey
+        BBP.activeProfileKey = activeKey
+        BBP.profileUnresolved = nil
+        return
+    end
+
+    -- MISMATCH: the hinted profile was WRONG for this character. Because the whole
+    -- session ran against the SCRATCH, the persisted profiles were NEVER touched —
+    -- no foreign profile got dirtied (this is the fix). A live rebind + additive
+    -- merge cannot reconstruct the correct profile's one-shot init this session, so
+    -- persist the correct assignment + converging hint and do one clean reboot.
+    --
+    -- CONVERGENCE INVARIANT (invisible constraint — do not remove): we set
+    -- root.lastActiveProfile = activeKey BEFORE reloading. On the reboot, if
+    -- identity is AGAIN unresolvable at ADDON_LOADED, Activate's provisional path
+    -- copies its scratch FROM root.profiles[lastActiveProfile] == root.profiles[activeKey].
+    -- Then here hintKey == activeKey, so we take the equality (no-reload) branch
+    -- above. The reload therefore happens AT MOST once per identity change; the
+    -- steady state never reloads. The scratch is discarded by the reload itself.
+    root.lastActiveProfile = activeKey
+    BBP.activeProfileKey = activeKey
+    BBP.profileUnresolved = nil
+    ReloadUI()
+end
+
+local function Activate(root)
+    EnsureStructure(root)
+    BBP.dbRoot = root
+
+    local charKey = BuildCharKey()
+    if charKey then
+        -- Identity available now (the normal path on every current client).
+        local activeKey = ResolveActiveKey(root, charKey)
+        root.profileKeys[charKey] = activeKey
+        root.lastActiveProfile = activeKey
+        BBP.charKey = charKey
+        BBP.activeProfileKey = activeKey
+        BBP.profileUnresolved = nil
+
+        -- THE REBIND. The global now points at the active profile table for the
+        -- whole session. Every one of the ~10k BetterBlizzPlatesDB.* reads/writes
+        -- transparently targets the active profile. PLAYER_LOGOUT swaps it back.
+        BetterBlizzPlatesDB = root.profiles[activeKey]
+    else
+        -- Identity NOT available yet (Classic Era timing edge). Bind PROVISIONALLY
+        -- but persist NOTHING (no profileKeys entry, no BBP.charKey) so we never
+        -- write a sticky assignment under an UNKNOWN/empty identity. Retry at
+        -- PLAYER_LOGIN, when name/realm are guaranteed available.
+        --
+        -- Converging hint: derive from root.lastActiveProfile (the last profile
+        -- any character successfully activated) when it still exists, else Default.
+        -- This makes the provisional binding correct in virtually all real cases
+        -- (same character re-logging, single-profile accounts), so
+        -- ReactivateAtLogin usually takes the no-reload equality branch.
+        local hintKey = root.lastActiveProfile
+        if not (hintKey and root.profiles[hintKey]) then
+            hintKey = "Default"
+        end
+        -- CRITICAL: bind to a SCRATCH deep copy of the hinted profile, NOT to the
+        -- persisted profile table itself. All pre-PLAYER_LOGIN init runs now — the
+        -- main file's ADDON_LOADED handler AND its earlier-registered PLAYER_LOGIN
+        -- handler (both fire before ReactivateAtLogin) — and every write it makes
+        -- (one-shot migration flags, the additive default-merge, list updates,
+        -- reopenOptions clearing, font/CVar captures) lands on this throwaway table.
+        -- If the hint turns out WRONG for this character (mismatch branch below),
+        -- no persisted profile was ever dirtied — that is the whole point: init
+        -- must never contaminate a profile that may belong to a different character.
+        -- The scratch lives only in BBP.profileScratch; it is never stored in
+        -- root.profiles and never serialized (PLAYER_LOGOUT rebinds the global to
+        -- the root, not to the scratch).
+        local scratch = DeepCopy(root.profiles[hintKey])
+        BBP.profileScratch = scratch
+        BBP.charKey = nil
+        BBP.activeProfileKey = hintKey
+        BBP.profileUnresolved = true
+        BetterBlizzPlatesDB = scratch
+
+        local loginFrame = CreateFrame("Frame")
+        loginFrame:RegisterEvent("PLAYER_LOGIN")
+        loginFrame:SetScript("OnEvent", function(self)
+            self:UnregisterEvent("PLAYER_LOGIN")
+            ReactivateAtLogin(root)
+        end)
+    end
+end
+
+-- Build a fully-seeded fresh profile table for CreateProfile/ResetProfile.
+-- Result contract: pure addon defaults (deep-copied from the flavor's exported
+-- defaultSettings, so no reference aliasing between profiles) PLUS, via the
+-- per-flavor hook BBP.FinalizeNewProfile, every one-shot bootstrap/migration
+-- flag pre-marked done and the client-descriptive captures (Blizzard font
+-- defaults, nameplateStyle) carried from `source`. This means the reload that
+-- follows creation/reset performs NO CVar snapshot, NO onboarding replay, and
+-- NO destructive migration against the new profile — instead of the old
+-- behavior where an empty {} inherited the previous profile's CVar state via
+-- the legacy first-run path.
+local function BuildFreshProfile(source)
+    local fresh = DeepCopy(BBP.defaultSettings or {})
+    if type(BBP.FinalizeNewProfile) == "function" then
+        BBP.FinalizeNewProfile(fresh, source or {})
+    else
+        -- Defensive fallback if a flavor failed to export the hook: at minimum
+        -- suppress the first-run bootstrap so we never snapshot CVars/onboard.
+        fresh.firstSaveComplete = true
+        fresh.hasSaved = true
+    end
+    return fresh
+end
+BBP.BuildFreshProfile = BuildFreshProfile
+
+--#########################################
+-- Public API
+
+function BBP.GetGlobalDB()
+    local root = BBP.dbRoot
+    if root then
+        root.global = root.global or {}
+        return root.global
+    end
+    -- Should not happen (only valid after ADDON_LOADED); return a throwaway so
+    -- callers never index nil.
+    return {}
+end
+
+function BBP.GetProfiles()
+    local list = {}
+    local root = BBP.dbRoot
+    if root and root.profiles then
+        for name in pairs(root.profiles) do
+            list[#list + 1] = name
+        end
+        table.sort(list)
+    end
+    return list
+end
+
+function BBP.GetCurrentProfileName()
+    return BBP.activeProfileKey or "Default"
+end
+
+-- SetProfile is THE single switch path: assign this character's profile and
+-- reload. Confirmation happens in the popup so a cancel changes nothing.
+function BBP.SetProfile(name)
+    local root = BBP.dbRoot
+    if not root or type(name) ~= "string" then return end
+    if not root.profiles[name] then
+        BBP.Print("Profile \"" .. tostring(name) .. "\" does not exist.")
+        return
+    end
+    if name == BBP.GetCurrentProfileName() then
+        BBP.Print("Profile \"" .. name .. "\" is already active.")
+        return
+    end
+    if not BBP.charKey then
+        BBP.Print("Cannot switch profiles: character name/realm unavailable.")
+        return
+    end
+    BBP.pendingProfile = name
+    StaticPopup_Show("BBP_CONFIRM_PROFILE_SWITCH", name)
+end
+
+function BBP.CreateProfile(name)
+    name = Trim(name)
+    if name == "" then
+        BBP.Print("Profile name cannot be empty.")
+        return
+    end
+    local root = BBP.dbRoot
+    if not root then return end
+    if root.profiles[name] then
+        BBP.Print("A profile named \"" .. name .. "\" already exists.")
+        return
+    end
+    -- Fresh profile: deterministically seeded with pure defaults + one-shot
+    -- flags marked done + client-descriptive captures (see BuildFreshProfile).
+    -- No CVar snapshot, no onboarding replay on the post-switch reload.
+    root.profiles[name] = BuildFreshProfile(root.profiles[BBP.activeProfileKey])
+    -- Then switch to it (popup -> reload).
+    BBP.SetProfile(name)
+end
+
+-- Deep-copy the source profile INTO the active profile (AceDB semantics).
+function BBP.CopyProfile(sourceName)
+    local root = BBP.dbRoot
+    if not root or type(sourceName) ~= "string" then return end
+    if not root.profiles[sourceName] then
+        BBP.Print("Profile \"" .. tostring(sourceName) .. "\" does not exist.")
+        return
+    end
+    if sourceName == BBP.GetCurrentProfileName() then
+        BBP.Print("Cannot copy a profile onto itself.")
+        return
+    end
+    BBP.pendingCopy = sourceName
+    StaticPopup_Show("BBP_CONFIRM_PROFILE_COPY", sourceName, BBP.GetCurrentProfileName())
+end
+
+function BBP.DeleteProfile(name)
+    local root = BBP.dbRoot
+    if not root or type(name) ~= "string" then return end
+    if not root.profiles[name] then
+        BBP.Print("Profile \"" .. tostring(name) .. "\" does not exist.")
+        return
+    end
+    if name == "Default" then
+        -- Hard-block: Default holds the migrated settings and is the fallback that
+        -- every unassigned character resolves to. It must always exist.
+        BBP.Print("You cannot delete the Default profile.")
+        return
+    end
+    if name == BBP.GetCurrentProfileName() then
+        BBP.Print("You cannot delete the profile you are currently using.")
+        return
+    end
+    root.profiles[name] = nil
+    -- Characters assigned to it fall back to Default on their next login.
+    for k, v in pairs(root.profileKeys) do
+        if v == name then
+            root.profileKeys[k] = nil
+        end
+    end
+    -- Keep the converging hint valid: if it pointed at the deleted profile, fall
+    -- back to Default (a nil/stale hint is also tolerated by Activate's provisional
+    -- path, but resetting it here keeps the persisted state clean).
+    if root.lastActiveProfile == name then
+        root.lastActiveProfile = "Default"
+    end
+    BBP.Print("Deleted profile \"" .. name .. "\".")
+end
+
+-- Wipe the active profile in place -> reload (defaults re-merge on load).
+function BBP.ResetProfile()
+    if not BBP.dbRoot then return end
+    StaticPopup_Show("BBP_CONFIRM_PROFILE_RESET", BBP.GetCurrentProfileName())
+end
+
+--#########################################
+-- Confirmation popups
+
+StaticPopupDialogs["BBP_CONFIRM_PROFILE_SWITCH"] = {
+    text = "Switch BetterBlizzPlates profile to \"%s\"?\n\nThis will reload your UI.",
+    button1 = "Confirm",
+    button2 = "Cancel",
+    OnAccept = function()
+        local name = BBP.pendingProfile
+        local root = BBP.dbRoot
+        if name and root and root.profiles[name] and BBP.charKey then
+            root.profileKeys[BBP.charKey] = name
+            root.lastActiveProfile = name
+            ReloadUI()
+        end
+    end,
+    timeout = 0,
+    whileDead = true,
+    hideOnEscape = true,
+    preferredIndex = 3,
+}
+
+StaticPopupDialogs["BBP_CONFIRM_PROFILE_COPY"] = {
+    text = "Copy the settings from \"%s\" into your current profile \"%s\"?\n\nThis overwrites the current profile and reloads your UI.",
+    button1 = "Confirm",
+    button2 = "Cancel",
+    OnAccept = function()
+        local src = BBP.pendingCopy
+        local root = BBP.dbRoot
+        if not (src and root and root.profiles[src]) then return end
+        local active = root.profiles[BBP.activeProfileKey]
+        if not active then return end
+        WipeInPlace(active)
+        for k, v in pairs(root.profiles[src]) do
+            active[k] = DeepCopy(v)
+        end
+        ReloadUI()
+    end,
+    timeout = 0,
+    whileDead = true,
+    hideOnEscape = true,
+    preferredIndex = 3,
+}
+
+StaticPopupDialogs["BBP_CONFIRM_PROFILE_RESET"] = {
+    text = "Reset the current profile \"%s\" to defaults?\n\nThis will reload your UI.",
+    button1 = "Confirm",
+    button2 = "Cancel",
+    OnAccept = function()
+        local root = BBP.dbRoot
+        local active = root and root.profiles[BBP.activeProfileKey]
+        if not active then return end
+        -- Seed defaults + flags + client-descriptive captures FROM the current
+        -- (still-intact) active profile BEFORE wiping, then copy the seeded
+        -- result back into the SAME table so references held elsewhere (the
+        -- rebound global) stay valid. Same deterministic contract as create:
+        -- no CVar snapshot / onboarding replay on the reset reload.
+        local fresh = BuildFreshProfile(active)
+        WipeInPlace(active)
+        for k, v in pairs(fresh) do
+            active[k] = v
+        end
+        active.reopenOptions = true
+        ReloadUI()
+    end,
+    timeout = 0,
+    whileDead = true,
+    hideOnEscape = true,
+    preferredIndex = 3,
+}
+
+--#########################################
+-- Slash: /bbp profile [<name>]
+
+local function HandleProfileSlash(rest)
+    rest = Trim(rest)
+    if rest == "" then
+        BBP.Print("Current profile: " .. BBP.GetCurrentProfileName())
+        local list = BBP.GetProfiles()
+        DEFAULT_CHAT_FRAME:AddMessage("|A:gmchat-icon-blizz:16:16|a Profiles: " .. table.concat(list, ", "))
+        DEFAULT_CHAT_FRAME:AddMessage("|A:gmchat-icon-blizz:16:16|a Use /bbp profile <name> to switch.")
+    else
+        local root = BBP.dbRoot
+        if root and root.profiles[rest] then
+            BBP.SetProfile(rest)
+        else
+            BBP.Print("No profile named \"" .. rest .. "\". Use /bbp profile to list them.")
+        end
+    end
+end
+
+-- Wrap the existing SlashCmdList["BBP"] (defined at the main file's file scope,
+-- which runs before any ADDON_LOADED, so it exists by the time we hook).
+local function HookSlash()
+    if BBP.profilesSlashHooked then return end
+    local original = SlashCmdList and SlashCmdList["BBP"]
+    if type(original) ~= "function" then return end
+    SlashCmdList["BBP"] = function(msg)
+        msg = msg or ""
+        -- Keep the name's original case; only the subcommand is matched.
+        local cmd, rest = msg:match("^(%S*)%s*(.-)$")
+        if cmd and cmd:lower() == "profile" then
+            HandleProfileSlash(rest)
+            return
+        end
+        return original(msg)
+    end
+    BBP.profilesSlashHooked = true
+end
+
+--#########################################
+-- Bootstrap
+
+local function Initialize()
+    if BBP.profilesInitialized then return end
+
+    local root = BetterBlizzPlatesDB
+    if type(root) ~= "table" then
+        root = {}
+        BetterBlizzPlatesDB = root
+    end
+
+    Migrate(root)
+    Activate(root)
+    HookSlash()
+
+    -- Register the logout swap HERE (inside our ADDON_LOADED), not at file
+    -- scope. The main file registers its PLAYER_LOGOUT handler at file scope
+    -- (which runs before any ADDON_LOADED), so registering ours now guarantees
+    -- ours fires AFTER it. That matters: the main file's logout handler reads
+    -- profile settings (e.g. disableCVarForceOnLogin), so the global must still
+    -- point at the active profile while it runs; we swap to the root only after.
+    local logoutFrame = CreateFrame("Frame")
+    logoutFrame:RegisterEvent("PLAYER_LOGOUT")
+    logoutFrame:SetScript("OnEvent", function()
+        if BBP.dbRoot then
+            BetterBlizzPlatesDB = BBP.dbRoot
+        end
+    end)
+
+    BBP.profilesInitialized = true
+end
+
+local loader = CreateFrame("Frame")
+loader:RegisterEvent("ADDON_LOADED")
+loader:SetScript("OnEvent", function(_, event, name)
+    if event == "ADDON_LOADED" and name == ADDON then
+        Initialize()
+    end
+end)

--- a/temp_tbc/BetterBlizzPlates.lua
+++ b/temp_tbc/BetterBlizzPlates.lua
@@ -1245,6 +1245,46 @@ local function InitializeSavedVariables()
     BBP.defaultTotemIndicatorNpcList = defaultSettings.totemIndicatorNpcList
 end
 
+-- Profiles engine hooks (see temp_shared/Profiles.lua).
+BBP.defaultSettings = defaultSettings
+BBP.InitializeSavedVariables = InitializeSavedVariables
+
+-- Pre-mark this flavor's one-shot bootstrap/migration flags "done" on a freshly
+-- created/reset profile so the post-switch reload does NOT snapshot CVars,
+-- capture client fonts, run destructive DB cleans, or replay onboarding popups
+-- (MoP update, TBC totem-list popups); then carry client-descriptive captures
+-- from the source profile.
+function BBP.FinalizeNewProfile(profile, source)
+    source = source or {}
+    profile.firstSaveComplete = true
+    profile.hasSaved = true
+    profile.mopUpdated = true
+    profile.mopBetaUpdated2 = true
+    profile.mopBetaUpdated3 = true
+    profile.totemListUpdateMop1 = true
+    profile.totemListUpdateMop2 = true
+    profile.totemListUpdateMop3 = true
+    profile.tbcTotemListUpdate1 = true
+    profile.friendlyNameplateTogglesUpdated = true
+    profile.auraWhitelistColorsUpdated = true
+    profile.auraWhitelistAlphaUpdated = true
+    profile.castBarIconPosReset = true
+    profile.cleanedScaleScale = true
+    profile.nameplateResourcePositionFix = true
+    for _, k in ipairs({
+        "defaultLargeNamePlateFont", "defaultLargeFontSize", "defaultLargeNamePlateFontFlags",
+        "defaultNamePlateFont", "defaultFontSize", "defaultNamePlateFontFlags",
+        "defaultNamePlateOutlinedFont", "defaultOutlinedFontSize", "defaultNamePlateOutlinedFontFlags",
+        "old_defaultLargeNamePlateFont", "old_defaultLargeFontSize", "old_defaultLargeNamePlateFontFlags",
+        "old_defaultNamePlateFont", "old_defaultFontSize", "old_defaultNamePlateFontFlags",
+        "nameplateStyle",
+    }) do
+        if source[k] ~= nil then
+            profile[k] = source[k]
+        end
+    end
+end
+
 function BBP.ResetTotemList()
     BetterBlizzPlatesDB.totemIndicatorNpcList = {}
     BetterBlizzPlatesDB.totemIndicatorNpcList = defaultSettings.totemIndicatorNpcList
@@ -1523,7 +1563,9 @@ local function ResetNameplates()
 end
 
 local function ResetBBP()
-    BetterBlizzPlatesDB = {}
+    -- Wipe the active profile in place (do NOT rebind the global: the logout
+    -- swap would discard a new table and the reset would silently no-op).
+    for k in pairs(BetterBlizzPlatesDB) do BetterBlizzPlatesDB[k] = nil end
 
     ResetNameplates()
 


### PR DESCRIPTION



Hey Bodify! First off: thank you for BetterBlizzPlates, can't do without it. 

But I had a problem: as healer and dd I need different settings. I copy-pasted every time i switched chars, not the life I want to live. So this PR ads **user-managed profiles**, AceDB addon style.

Right away: this IS agent-built, this is NOT slop. I am a software engineer, albeit no experience with Lua. 



## What it does

- **Create / switch / copy / delete / reset named profiles** from a new "Profiles" options panel (next to Import & Export), modeled on the standard AceDBOptions layout everyone knows from sArena, WeakAuras etc.
- **Per-character assignment that sticks**: each character remembers its profile across sessions until changed. `/bbp profile <name>` works too.
- **All six flavors** — the engine is one shared file (`temp_shared/Profiles.lua`, loaded by every TOC right after `init.lua`, same pattern as `ImportExport.lua`); the panel is added to each loaded gui.lua.
- **Zero new dependencies** — plain Lua on the existing saved variable, no Ace libraries added.



## Design choices (and why)

- **Existing users are migrated once, losslessly, into a "Default" profile.** The migration is idempotent (guarded by a structure sentinel + `dbVersion`), moves rather than copies, and every character maps to Default — so after updating, nothing visibly changes for anyone until they deliberately create a second profile.
- **No call-site changes.** The saved-variable root becomes `{ profiles, profileKeys, global, dbVersion }`, but the global `BetterBlizzPlatesDB` stays bound to the *active profile table* during the session (rebound to the root on `PLAYER_LOGOUT` for serialization). Since the codebase only aliases the DB inside function bodies, the ~10k existing reads keep working untouched.
- **Profile switches confirm + ReloadUI**, deliberately matching how preset profiles and full-profile import already behave (and what Plater recommends on its profile switches). A live-switch path could be added later, but reload-on-switch is bulletproof with the GUI's construction-time widget state.
- **New/reset profiles are seeded from clean defaults** (plus the client-descriptive font captures), with the one-shot bootstrap flags pre-set — so a fresh profile doesn't inherit the previous profile's CVar snapshot and doesn't re-trigger onboarding.
- **Presets and import/export now apply to the active profile** instead of the whole saved variable — existing `!BBP` strings stay compatible in both directions. `BBPCVarBackupsDB` is untouched. "Default" is protected from deletion; deleting a profile that other characters use falls them back to Default at next login.



## Testing

- Tested in-game on Retail/Midnight: lossless migration of my real (large) DB, create/switch/copy/delete/reset, per-character stickiness across relogs, `/reload` persistence mid-session, presets and full-profile import targeting only the active profile.
- Classic flavors (Era/Anniversary) carry the identical shared engine and a byte-identical panel; I'm running the same checklist there now and will note results in the PR.
- The edge case I'd most appreciate your eyes on: the deferred-activation path in `Profiles.lua` (when `UnitName`/`GetRealmName` isn't ready at `ADDON_LOADED` — defensive, mainly a Classic-timing concern). It binds a scratch copy and resolves at `PLAYER_LOGIN`, never persisting a placeholder key.



## Hope you consider merging!

I am Mmw on Doomhammer/EU. Hope this makes it into the next build :)
